### PR TITLE
Add entrypoint for CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "async": "~0.2.10",
     "gulp-requirejs": "https://github.com/pago/gulp-requirejs/tarball/patch-1"
   },
+  "main": "handlebones.js",
   "scripts": {
     "test": "gulp"
   }


### PR DESCRIPTION
This allows tools like Browserify and Webpack to require Handlebones as `handlebones` instead of `handlebones/handlebones`.
